### PR TITLE
Update SubscriptionCenterPage.page

### DIFF
--- a/force-app/main/default/pages/SubscriptionCenterPage.page
+++ b/force-app/main/default/pages/SubscriptionCenterPage.page
@@ -323,7 +323,7 @@
     <div class="container txtCenter ">
         <img src="{!URLFOR($Resource.ToysBabiesLogo,'toysRUs.svg')}" class="head_toyLogo" />
         <img src="{!URLFOR($Resource.ToysBabiesLogo,'babiesRUs.svg')}" class="head_babyLogo" />
-        <img src="{!$Resource.LittilRiseLogo}" class="head_babyLogo" />
+       <!-- <img src="{!$Resource.LittilRiseLogo}" class="head_babyLogo" /> -->
     </div>
     <apex:form >
 
@@ -533,10 +533,10 @@
                                             <img src="{!URLFOR($Resource.ToysBabiesLogo,'babiesRUs.svg')}" class="babyLogo" />
                                             <a href="https://www.babiesrus.ca/en/home?utm_source=prefcentre" class="shopBtn">Shop Now</a>
                                         </div>
-                                        <div class="slds-col">
+                                      <!--   <div class="slds-col">
                                             <img src="{!$Resource.LittilRiseLogo}" class="" />
                                             <a href="https://www.riselittleearthling.ca/en/home" class="shopBtn">Shop Now</a>
-                                        </div>
+                                        </div> -->
                                     </div>
                                 </div>
                                 <div style="display:none" id='thanksfr'>
@@ -550,10 +550,10 @@
                                             <img src="{!URLFOR($Resource.ToysBabiesLogo,'babiesRUs.svg')}" class="babyLogo" />
                                             <a href="https://www.babiesrus.ca/fr/home?utm_source=prefcentre" class="shopBtn"> Magasinez </a>
                                         </div>
-                                        <div class="slds-col">
+                                     <!--    <div class="slds-col">
                                             <img src="{!$Resource.LittilRiseLogo}" class="" />
                                             <a href="https://www.riselittleearthling.ca/fr/home" class="shopBtn"> Magasinez </a>
-                                        </div>
+                                        </div> -->
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
As a part of removal of RLE presence across TRU and BRU, RLE logo and link has to be removed from the location identified in this ticket. ie from the Preference center -"Save Profile" popup
ENV: Development, Staging, Production
Desktop and Mobile 
English and French
Steps: 
Go to the website toysrus.ca
Click on login to my account > Login/Register 
Login to account 
under my account click EDIT
Scroll down and click Update Preferences 
From the Preference center scroll down and click SAVE PROFILE
Expected: A popup is displayed with TRU and BRU logos with "Shop now" on it center aligned. 
Actual : TRU BRU and RLE logos with Shop now is displayed. 